### PR TITLE
Fix for Issue #1: Allow dash character in search term

### DIFF
--- a/spot.sh
+++ b/spot.sh
@@ -38,7 +38,7 @@ EOF
 }
 
 # parse options
-while [[ "$1" =~ "-" ]]; do
+while [[ "$1" =~ ^- ]]; do
     case $1 in
         -s | --sensitive )
           sensitive=1


### PR DESCRIPTION
Fixed Issue #1 by changing the parse options regex to search for a dash at the **beginning** of $1.
