### PR TITLE
Add -l and -- options

### DIFF
--- a/spot.sh
+++ b/spot.sh
@@ -44,6 +44,7 @@ usage() {
     -U, --update            Update spot(1)
     -V, --version           Output version
     -h, --help              This message.
+    --                      End of options
 
 EOF
 }
@@ -60,7 +61,7 @@ update() {
 }
 
 # parse options
-while [[ "$1" =~ ^- ]]; do
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
   case $1 in
     -V | --version )
       echo $version
@@ -95,6 +96,7 @@ while [[ "$1" =~ ^- ]]; do
   esac
   shift
 done
+if [[ "$1" == "--" ]]; then shift; fi
 
 # check for directory as first parameter
 if [[ "$1" =~ / ]]; then
@@ -141,13 +143,13 @@ fi
 # run search
 if [ $colors ]; then
   eval "find "$dir" -type f $exclude -print0" \
-    | GREP_COLOR="1;33;40" xargs -0 grep $grepopt "`echo $@`" \
+    | GREP_COLOR="1;33;40" xargs -0 grep $grepopt -e "`echo $@`" \
     | sed "s/^\([^:]*:\)\(.*\)/  \\
   $cyan\1$reset  \\
   \2 /"
 else
   eval "find "$dir" -type f $exclude -print0" \
-    | xargs -0 grep $grepopt "$@" \
+    | xargs -0 grep $grepopt -e "$@" \
     | sed "s/^\([^:]*:\)\(.*\)/  \\
   \1  \\
   \2 /"


### PR DESCRIPTION
This PR adds support for two new options: -l (lowercase L) to only list the names of files with matches, similar to grep; and -- to explicitly indicate the end of options, so matching patterns can start with a hyphen.
