### PR TITLE
Handle long lines

### DIFF
--- a/spot.sh
+++ b/spot.sh
@@ -157,6 +157,7 @@ $cyan\1$reset  \\
     i = index($0, "\033[1;33;40m")
     str = $0
     while(i > 0) {
+      # Clean coloring
       line = reset
 
       if (linenums) {
@@ -196,4 +197,4 @@ $cyan\1$reset  \\
   }'
 
 echo ""
-tput sgr0
+tput sgr0 # Clean leftover colors


### PR DESCRIPTION
For lines longer than 500 characters:
- Split line per match (and per 500 chars as window length) and do all the following steps for each:
  - Print line number (if not disabled)
  - Take some characters before and after the match (keeping a 500 char window length) as context
  - Add `...` before the match if it is not within the first characters of the line
  - Strip colors if option given
  - Print individual match
  - Move the window

Before and after screenshots:
https://cloudup.com/cM9D7mBIsyp
