### PR TITLE
allow user-specified PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 MANTASTIC = http://mantastic.herokuapp.com
 
 docs: spot.1


### PR DESCRIPTION
Make the PREFIX optional, so users (me) can run `PREFIX=~/.local make install`