### PR TITLE
Bpkg install fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 MANTASTIC = http://mantastic.herokuapp.com
 
 docs: spot.1

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ npm install -g spot
 Or if you have [bpkg](https://github.com/bpkg/bpkg)
 
 ```
-$ bpkg install -g spot
+$ bpkg install -g rauchg/spot
 ```
 
 You're done! Otherwise, run this command:


### PR DESCRIPTION
I had some trouble installing spot since I don't use the default prefix of `/usr/local` this change makes installing with a command like `PREFIX=~/.local bpkg install -g rauchg/spot` do the right thing.