### PR TITLE
fix bugs when searching for multiple words or for spaces

### DIFF
--- a/spot.sh
+++ b/spot.sh
@@ -118,7 +118,7 @@ if [[ "$1" =~ / ]]; then
 fi
 
 # check for empty search
-if [ -z "$@" ]; then
+if [[ -z "$@" ]]; then
   echo "(no search term. \`spot -h\` for usage)"
   exit 1
 fi
@@ -160,7 +160,7 @@ fi
 
 # run search
 eval "find $dir $findopt -type f $exclude -print0" \
-  | GREP_COLOR="1;33;40" xargs -0 grep "${grepopt[@]}" -e "$@" \
+  | GREP_COLOR="1;33;40" xargs -0 grep "${grepopt[@]}" -e "`echo \"$@\"`" \
   | sed "s/^\([^:]*:\)\(.*\)/  \\
 $cyan\1$reset  \\
 \2 /" \

--- a/spot.sh
+++ b/spot.sh
@@ -110,7 +110,7 @@ done
 if [[ "$1" == "--" ]]; then shift; fi
 
 # check for directory as first parameter
-if [[ "$1" =~ / ]]; then
+if [[ "$1" =~ / ]] && [[ "$1" =~ [^\/] ]]; then
   if [ -d "$1" ]; then
     dir=${1/%\//}
     shift


### PR DESCRIPTION
This is an extension of https://github.com/rauchg/spot/pull/32

Examples contain output from running spot inside its repository directory.

The change on line 121 is required to suppress an error message printed when searching for multiple words:

```
$ spot force color # old version
./spot.sh: line 121: [: force: binary operator expected

./spot.sh:
149:# add force colors

$ spot force color # new version
./spot.sh:
149:# add force colors
```

On line 163, replacing `"$@"` with ``"`echo $@`"`` is required for multiple word search to work properly:

```
$ spot force color # old version, in the results only 'force' is highlighted
grep: color: No such file or directory

./spot.sh:
45:    -s, --sensitive         Force case sensitive search.

./spot.sh:
46:    -i, --insensitive       Force case insensitive search.

./spot.sh:
48:    -C, --no-colors         Force avoid colors.

./spot.sh:
149:# add force colors


$ spot force color # new version, in the results the entire 'force color' phrase is highlighted
./spot.sh:
149:# add force colors
```

On that line, adding quotation marks around the `$@` in the echo is required to make searching for an empty string to work:

```
$ spot "                " # version from other PR: "`echo $@`"
   [matches every single line in every file in the directory]

$ spot "                " # new version: "`echo \"$@\"`"
   [matches a single line with many spaces in it; the spaces are highlighted]
./spot.sh:
54:    --                      End of options
```

Finally, this fixes an error when trying to search for slashes:
```
$ spot //   # old version
(no search term. `spot -h` for usage)

$ spot //   # new version

./README.md:
19:![](https://cldup.com/TiVORMfp77-1200x1200.png)

# more results omitted

./spot.sh:
115:    dir=${1/%\//}

./spot.1:
2:.\" http://github.com/kapouer/ronnjs/
```

On line 113, the '//' search term is detected as a directory (at least on bash, '//', '///', etc. are interpreted as just '/' and so pass the `-d` test on line 114). The additional regex test on 113 verifies that there is at least one non-'/' character before counting it as a manually-specified search directory. The only issue is that this makes it impossible to do a search on the entire filesystem by doing `spot / searchTerm` - the '/' is not detected as a directory since it does not contain a non-'/' character. The two workarounds are to either:

- remove the second test on line 113 temporarily, or
- `cd /; spot ./ searchTerm`
